### PR TITLE
ci: bump actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,7 +13,7 @@ jobs:
         outputs:
             wp-versions: ${{ steps.versions.outputs.wp-versions }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
             - id: versions
               run: |
                   min=""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+
+- Bump GitHub Actions off the deprecated Node 20 runtime: `actions/checkout`
+  v4→v5. GitHub forces JavaScript actions onto Node 24 starting 2026-06-16.


### PR DESCRIPTION
## Background

GitHub forces JavaScript actions off the deprecated Node 20 runtime starting **2026-06-16**, with full removal on 2026-09-16.

## Changes

- `actions/checkout` v4→v5

Each target is the first major of that action on the Node 24 runtime. Documented under `## [Unreleased]` so it ships without forcing a release.

Closes #7